### PR TITLE
Implement cleanup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This plugin works alongside the [Tasks plugin](https://github.com/obsidian-tasks-group/obsidian-tasks) to keep your task lists clean. It removes completed repeating tasks after they have been recreated by the Tasks plugin.
 
+Use the **Tidy Completed Tasks** command to scan your vault and delete any completed repeating tasks.
+
 ## Development
 
 This project follows the structure of the [Obsidian Sample Plugin](https://github.com/obsidianmd/obsidian-sample-plugin). To get started:

--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,36 @@ const DEFAULT_SETTINGS: TidyTasksSettings = {
 export default class TidyTasksPlugin extends Plugin {
     settings: TidyTasksSettings;
 
+    async tidyCompletedTasks() {
+        if (!this.settings.removeCompleted) {
+            new Notice('Tidy Tasks is disabled in settings');
+            return;
+        }
+
+        const files = this.app.vault.getMarkdownFiles();
+        let removed = 0;
+
+        for (const file of files) {
+            const content = await this.app.vault.read(file);
+            const lines = content.split(/\r?\n/);
+            const newLines: string[] = [];
+
+            for (const line of lines) {
+                if (/^- \[[xX]\] .*(🔁|every)/.test(line)) {
+                    removed++;
+                    continue;
+                }
+                newLines.push(line);
+            }
+
+            if (newLines.length !== lines.length) {
+                await this.app.vault.modify(file, newLines.join('\n'));
+            }
+        }
+
+        new Notice(`Removed ${removed} completed repeating task${removed === 1 ? '' : 's'}.`);
+    }
+
     async onload() {
         await this.loadSettings();
 
@@ -22,9 +52,7 @@ export default class TidyTasksPlugin extends Plugin {
         this.addCommand({
             id: 'tidy-completed-tasks',
             name: 'Tidy Completed Tasks',
-            callback: () => {
-                new Notice('Would tidy completed tasks');
-            }
+            callback: () => this.tidyCompletedTasks()
         });
 
         this.addSettingTab(new TidyTasksSettingTab(this.app, this));


### PR DESCRIPTION
## Summary
- implement command to clean completed repeating tasks
- document how to trigger cleanup

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68405e5954148326a5963ff626f81326