### PR TITLE
Add test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This project follows the structure of the [Obsidian Sample Plugin](https://githu
 1. Install NodeJS (v16 or newer).
 2. Run `npm install` to install dependencies.
 3. Run `npm run dev` to build the plugin in watch mode.
-4. Copy `main.js`, `styles.css` and `manifest.json` into your vault's `.obsidian/plugins/tidy-tasks/` folder.
-5. Enable the plugin in Obsidian.
+4. Run `npm test` to verify the project builds correctly.
+5. Copy `main.js`, `styles.css` and `manifest.json` into your vault's `.obsidian/plugins/tidy-tasks/` folder.
+6. Enable the plugin in Obsidian.
 
 ## Building for release
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "dev": "node esbuild.config.mjs",
         "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-        "version": "node version-bump.mjs && git add manifest.json versions.json"
+        "version": "node version-bump.mjs && git add manifest.json versions.json",
+        "test": "npm run build"
     },
     "keywords": [],
     "author": "Matthew Gromer",


### PR DESCRIPTION
## Summary
- add `npm test` script that calls the build step
- document the test script in the development instructions

## Testing
- `npm test`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_b_6840669dfda883269490db91211537d9