### PR TITLE
Remove unused Obsidian imports

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { App, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
 interface TidyTasksSettings {
     removeCompleted: boolean;


### PR DESCRIPTION
## Summary
- clean up unused imports from `main.ts`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6840676a37348326b548cf57c644761d