### PR TITLE
Preserve line endings when tidying

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,7 @@ export default class TidyTasksPlugin extends Plugin {
 
         for (const file of files) {
             const content = await this.app.vault.read(file);
+            const newline = content.includes('\r\n') ? '\r\n' : '\n';
             const lines = content.split(/\r?\n/);
             const newLines: string[] = [];
 
@@ -34,7 +35,7 @@ export default class TidyTasksPlugin extends Plugin {
             }
 
             if (newLines.length !== lines.length) {
-                await this.app.vault.modify(file, newLines.join('\n'));
+                await this.app.vault.modify(file, newLines.join(newline));
             }
         }
 


### PR DESCRIPTION
## Summary
- keep the original newline style when modifying a markdown file

## Testing
- `npm test`
- manual test of tidy logic on text containing `\r\n`

------
https://chatgpt.com/codex/tasks/task_b_68406b0f910083268551dd1a67800c80